### PR TITLE
Resolves C2696 error while using VS 2017

### DIFF
--- a/include/tins/sniffer.h
+++ b/include/tins/sniffer.h
@@ -678,7 +678,7 @@ void Tins::BaseSniffer::sniff_loop(Functor function, uint32_t max_packets) {
                 return;
             }
             #else
-            if (!function(*it->pdu())) {
+            if (!function((Tins::Packet &)*it->pdu())) {
                 return;
             }
             #endif


### PR DESCRIPTION
This resolves C2696 error on VS 2017 and up issue #360